### PR TITLE
Fix bridging NSErrors to Errors that made the program crash

### DIFF
--- a/Sources/NetworkStackError.swift
+++ b/Sources/NetworkStackError.swift
@@ -20,17 +20,17 @@ import Foundation
 
 public enum NetworkStackError: Error {
   /// No internet, roaming off, data not allowed, call active, …
-  case noInternet(error: Error)
+  case noInternet(error: NSError)
   /// DNS Lookup failed, Host unreachable, …
-  case serverUnreachable(error: Error)
+  case serverUnreachable(error: NSError)
   /// Invalid request, Fail to parse JSON, Unable to decode payload…
-  case badServerResponse(error: Error)
+  case badServerResponse(error: NSError)
   /// Response in 4xx-5xx range
   case http(httpURLResponse: HTTPURLResponse, data: Data?)
   /// Fail to parse response
   case parseError
   /// Other, unclassified error
-  case otherError(error: Error)
+  case otherError(error: NSError)
   /// Request building has failed
   case requestBuildFail
   /// Upload manager has not been setup


### PR DESCRIPTION
We're forced to compare with NSError because there's a bug in Xcode 8.2 / Swift 3.0 when bridging NSErrors to Errors makes the program crash (BAD_INSTRUCTION) — Solved in 8.3